### PR TITLE
✨ Add scene controller

### DIFF
--- a/racer-tracer/config.yml
+++ b/racer-tracer/config.yml
@@ -23,4 +23,4 @@ loader:
 image_output_dir: "../"
 
 image_action:
-  SavePng # (SavePng, WaitForSignal)
+  WaitForSignal # (SavePng, WaitForSignal)

--- a/racer-tracer/src/config.rs
+++ b/racer-tracer/src/config.rs
@@ -6,13 +6,13 @@ use structopt::StructOpt;
 
 use crate::error::TracerError;
 
-#[derive(Default, Debug, Deserialize)]
+#[derive(Default, Clone, Debug, Deserialize)]
 pub struct Screen {
     pub height: usize,
     pub width: usize,
 }
 
-#[derive(Default, Debug, Deserialize)]
+#[derive(Default, Clone, Debug, Deserialize)]
 pub struct RenderConfigData {
     pub samples: usize,
     pub max_depth: usize,
@@ -93,6 +93,23 @@ pub enum ImageAction {
     SavePng,
 }
 
+#[derive(StructOpt, Debug, Clone, Deserialize, Default)]
+pub enum ConfigSceneController {
+    #[default]
+    Interactive,
+}
+
+#[derive(StructOpt, Debug, Clone, Deserialize, Default)]
+pub enum Renderer {
+    #[default]
+    Cpu,
+    CpuPreview,
+}
+
+fn default_preview_renderer() -> Renderer {
+    Renderer::CpuPreview
+}
+
 impl FromStr for ImageAction {
     type Err = TracerError;
 
@@ -105,7 +122,7 @@ impl FromStr for ImageAction {
     }
 }
 
-#[derive(Default, Debug, Deserialize)]
+#[derive(Default, Clone, Debug, Deserialize)]
 pub struct Config {
     #[serde(default)]
     pub preview: RenderConfigData,
@@ -124,6 +141,15 @@ pub struct Config {
 
     #[serde(default)]
     pub image_output_dir: Option<PathBuf>,
+
+    #[serde(default)]
+    pub scene_controller: ConfigSceneController,
+
+    #[serde(default)]
+    pub renderer: Renderer,
+
+    #[serde(default = "default_preview_renderer")]
+    pub preview_renderer: Renderer,
 }
 
 impl Config {

--- a/racer-tracer/src/image_action.rs
+++ b/racer-tracer/src/image_action.rs
@@ -18,6 +18,7 @@ pub trait ImageAction: Send + Sync {
     fn action(
         &self,
         screen_buffer: &RwLock<Vec<u32>>,
+        cancel_event: &SignalEvent,
         event: &SignalEvent,
         config: &Config,
         log: Logger,
@@ -25,11 +26,11 @@ pub trait ImageAction: Send + Sync {
     ) -> Result<(), TracerError>;
 }
 
-impl From<&CImageAction> for Box<dyn ImageAction> {
+impl From<&CImageAction> for &dyn ImageAction {
     fn from(image_action: &CImageAction) -> Self {
         match image_action {
-            CImageAction::WaitForSignal => Box::new(WaitForSignal {}),
-            CImageAction::SavePng => Box::new(SavePng {}),
+            CImageAction::WaitForSignal => &WaitForSignal {} as &dyn ImageAction,
+            CImageAction::SavePng => &SavePng {} as &dyn ImageAction,
         }
     }
 }

--- a/racer-tracer/src/image_action/png.rs
+++ b/racer-tracer/src/image_action/png.rs
@@ -14,6 +14,7 @@ impl ImageAction for SavePng {
     fn action(
         &self,
         screen_buffer: &RwLock<Vec<u32>>,
+        _cancel_event: &SignalEvent,
         event: &SignalEvent,
         config: &Config,
         log: Logger,

--- a/racer-tracer/src/image_action/wait_for_signal.rs
+++ b/racer-tracer/src/image_action/wait_for_signal.rs
@@ -1,4 +1,4 @@
-use std::sync::RwLock;
+use std::{sync::RwLock, time::Duration};
 
 use slog::Logger;
 use synchronoise::SignalEvent;
@@ -17,6 +17,7 @@ impl ImageAction for WaitForSignal {
     fn action(
         &self,
         _screen_buffer: &RwLock<Vec<u32>>,
+        cancel_event: &SignalEvent,
         event: &SignalEvent,
         _config: &Config,
         _log: Logger,
@@ -24,7 +25,7 @@ impl ImageAction for WaitForSignal {
     ) -> Result<(), TracerError> {
         if !event.status() {
             write_term!(term, "Press R to resume.");
-            event.wait();
+            while !event.wait_timeout(Duration::from_secs(1)) && !cancel_event.status() {}
         }
         event.reset();
         Ok(())

--- a/racer-tracer/src/renderer/cpu.rs
+++ b/racer-tracer/src/renderer/cpu.rs
@@ -59,6 +59,9 @@ impl CpuRenderer {
                         buf[offset + row * image.screen_width + col] = color;
                     }
                 }
+                if let Some(updated) = rd.buffer_updated {
+                    updated.signal()
+                }
             })
     }
 

--- a/racer-tracer/src/renderer/cpu_scaled.rs
+++ b/racer-tracer/src/renderer/cpu_scaled.rs
@@ -81,6 +81,9 @@ impl CpuRendererScaled {
                         }
                     }
                 }
+                if let Some(updated) = rd.buffer_updated {
+                    updated.signal()
+                }
             })
     }
 }

--- a/racer-tracer/src/scene_controller.rs
+++ b/racer-tracer/src/scene_controller.rs
@@ -1,0 +1,37 @@
+pub mod interactive;
+
+use slog::Logger;
+
+use crate::{
+    camera::Camera, config::Config, error::TracerError, image::Image, key_inputs::KeyCallback,
+    scene::Scene, terminal::Terminal,
+};
+
+pub fn create_screen_buffer(image: &Image) -> Vec<u32> {
+    vec![0; image.width * image.height]
+}
+
+pub struct SceneData {
+    pub log: Logger,
+    pub term: Terminal,
+    pub config: Config,
+    pub scene: Scene,
+    pub camera: Camera,
+    pub image: Image,
+}
+
+pub trait SceneController: Send + Sync {
+    // Return a vector of key callbacks. The provided closure will be
+    // called when the corresponding key is release/pressed.
+    fn get_inputs(&self) -> Vec<KeyCallback>;
+
+    // Render function
+    fn render(&self) -> Result<(), TracerError>;
+
+    // Returns the screen buffer produced by the scene controller.
+    // Returns None if no new buffer is available
+    fn get_buffer(&self) -> Result<Option<Vec<u32>>, TracerError>;
+
+    // Called when the application wants to exit.
+    fn stop(&self);
+}

--- a/racer-tracer/src/scene_controller/interactive.rs
+++ b/racer-tracer/src/scene_controller/interactive.rs
@@ -1,0 +1,209 @@
+use std::{
+    sync::RwLock,
+    time::{Duration, Instant},
+};
+
+use minifb::Key;
+use slog::Logger;
+use synchronoise::SignalEvent;
+
+use crate::{
+    camera::Camera,
+    config::Config,
+    error::TracerError,
+    image::Image,
+    image_action::ImageAction,
+    key_inputs::{KeyCallback, KeyEvent, KeyInputs},
+    renderer::{RenderData, Renderer},
+    scene::Scene,
+    terminal::Terminal,
+};
+
+use super::{create_screen_buffer, SceneController, SceneData};
+
+pub struct InteractiveScene<'renderer, 'action> {
+    screen_buffer: RwLock<Vec<u32>>,
+    preview_buffer: RwLock<Vec<u32>>,
+    camera_speed: f64,
+    render_image_event: SignalEvent,
+    buffer_updated: SignalEvent,
+    stop_event: SignalEvent,
+
+    log: Logger,
+    term: Terminal,
+    image_action: &'action dyn ImageAction,
+    config: Config,
+    scene: Scene,
+    camera: RwLock<Camera>,
+    image: Image,
+    renderer: &'renderer dyn Renderer,
+    renderer_preview: &'renderer dyn Renderer,
+}
+
+impl<'renderer, 'action> InteractiveScene<'renderer, 'action> {
+    pub fn new(scene_data: SceneData, camera_speed: f64) -> Self {
+        Self {
+            screen_buffer: RwLock::new(create_screen_buffer(&scene_data.image)),
+            preview_buffer: RwLock::new(create_screen_buffer(&scene_data.image)),
+            camera_speed,
+            render_image_event: SignalEvent::manual(false),
+            buffer_updated: SignalEvent::manual(false),
+            stop_event: SignalEvent::manual(false),
+
+            log: scene_data.log,
+            term: scene_data.term,
+            image_action: (&scene_data.config.image_action).into(),
+            scene: scene_data.scene,
+            camera: RwLock::new(scene_data.camera),
+            image: scene_data.image,
+            renderer: (&scene_data.config.renderer).into(),
+            renderer_preview: (&scene_data.config.preview_renderer).into(),
+            config: scene_data.config,
+        }
+    }
+}
+
+impl<'renderer, 'action> SceneController for InteractiveScene<'renderer, 'action> {
+    fn get_inputs(&self) -> Vec<KeyCallback> {
+        vec![
+            KeyInputs::input(KeyEvent::Release, Key::R, |_| {
+                self.render_image_event.signal();
+                Ok(())
+            }),
+            KeyInputs::input(KeyEvent::Down, Key::W, |dt| {
+                self.camera
+                    .write()
+                    .map_err(|e| TracerError::KeyError(e.to_string()))
+                    .map(|mut cam| {
+                        cam.go_forward(-dt * self.camera_speed);
+                    })
+            }),
+            KeyInputs::input(KeyEvent::Down, Key::S, |dt| {
+                self.camera
+                    .write()
+                    .map_err(|e| TracerError::KeyError(e.to_string()))
+                    .map(|mut cam| {
+                        cam.go_forward(dt * self.camera_speed);
+                    })
+            }),
+            KeyInputs::input(KeyEvent::Down, Key::A, |dt| {
+                self.camera
+                    .write()
+                    .map_err(|e| TracerError::KeyError(e.to_string()))
+                    .map(|mut cam| {
+                        cam.go_right(-dt * self.camera_speed);
+                    })
+            }),
+            KeyInputs::input(KeyEvent::Down, Key::D, |dt| {
+                self.camera
+                    .write()
+                    .map_err(|e| TracerError::KeyError(e.to_string()))
+                    .map(|mut cam| {
+                        cam.go_right(dt * self.camera_speed);
+                    })
+            }),
+        ]
+    }
+
+    fn get_buffer(&self) -> Result<Option<Vec<u32>>, TracerError> {
+        self.buffer_updated
+            .wait_timeout(Duration::from_secs(0))
+            .then_some(|| ())
+            .map_or(Ok(None), |_| {
+                self.screen_buffer
+                    .read()
+                    .map_err(|e| TracerError::FailedToAcquireLock(e.to_string()))
+                    .map(|v| Some(v.to_owned()))
+            })
+    }
+
+    fn render(&self) -> Result<(), TracerError> {
+        self.render_image_event
+            .wait_timeout(Duration::from_secs(0))
+            .then_some(|| ())
+            .map_or_else(
+                || {
+                    // Render preview
+                    self.render_image_event.reset();
+
+                    // We do not want partial screen updates for the preview.
+                    // Which is why we send in a different buffer.
+                    self.renderer_preview
+                        .render(RenderData {
+                            buffer: &self.preview_buffer,
+                            camera: &self.camera,
+                            image: &self.image,
+                            scene: &self.scene,
+                            config: &self.config,
+                            cancel_event: None,
+                            buffer_updated: None,
+                        })
+                        .and_then(|_| {
+                            self.screen_buffer
+                                .write()
+                                .map_err(|e| TracerError::FailedToAcquireLock(e.to_string()))
+                        })
+                        .and_then(|w_buffer| {
+                            self.preview_buffer
+                                .read()
+                                .map_err(|e| TracerError::FailedToAcquireLock(e.to_string()))
+                                .map(|r_buffer| (r_buffer, w_buffer))
+                        })
+                        .map(|(r_buffer, mut w_buffer)| {
+                            // For the preview we want the complete image
+                            // result before signaling the image is done.
+                            *w_buffer = r_buffer.to_owned();
+                            self.buffer_updated.signal();
+                        })
+                },
+                |_| {
+                    let render_time = Instant::now();
+                    self.render_image_event.reset();
+
+                    // When we render the final image we want partial
+                    // updates to the screen buffer. We send in our
+                    // original screen_buffer and the buffer_updated
+                    // signal. This will ensure that the window will
+                    // get updated with a new buffer as soon as a
+                    // thread finishes writing a block and we get
+                    // partial updates of the rendered image.
+                    self.renderer
+                        .render(RenderData {
+                            buffer: &self.screen_buffer,
+                            camera: &self.camera,
+                            image: &self.image,
+                            scene: &self.scene,
+                            config: &self.config,
+                            cancel_event: Some(&self.render_image_event),
+                            buffer_updated: Some(&self.buffer_updated),
+                        })
+                        .and_then(|_| {
+                            if !self.render_image_event.status() {
+                                info!(
+                                    self.log,
+                                    "It took {} seconds to render the image.",
+                                    Instant::now().duration_since(render_time).as_secs()
+                                );
+                            } else {
+                                info!(self.log, "Image render cancelled.");
+                            }
+
+                            self.image_action.action(
+                                &self.screen_buffer,
+                                &self.stop_event,
+                                &self.render_image_event,
+                                &self.config,
+                                self.log.new(o!("scope" => "image-action")),
+                                &self.term,
+                            )
+                        })
+                },
+            )
+    }
+
+    fn stop(&self) {
+        // If we are currently rendering anything we try to cancel it
+        self.render_image_event.signal();
+        self.stop_event.signal();
+    }
+}


### PR DESCRIPTION
Wanted to be able to for example move around freely in the scene but also have something that would for example follow key frames and render a gif.

Abstracted it with a scene controller. You can hook up keybinds and other thigns for it as well. Right now there is only the interactive scene controller which keep the behaviours previous to this change.

Now I could possibly switch it out with something that uses key frames to render several images to create for example a gif.

List of other Misc changes:
- Add configuration setting for scene controller (`scene_controller`)
- Add configuration setting for renderer
- Add configuration setting for preview renderer (`preview_renderer`)
- Add clone to Config.
- Add from implementation for Renderer to be created from the config object.
- Add cancel event to image action. An action could be blocking when the application wants to exit. Actions can now listen to the cancel event to exit early and not block.
- Fixed bug where WaitForSignal action would block after application tries to exit.
- Add method to KeyInputs to be able to take a list of callbacks instead of manually registering every callback one at the time.