### PR TITLE
✨ Add support for camera rotation

### DIFF
--- a/racer-tracer/Cargo.toml
+++ b/racer-tracer/Cargo.toml
@@ -20,4 +20,5 @@ slog-term = "2"
 slog = "2"
 slog-async = "2"
 console = "0.15"
+glam = "0.23.0"
 serde = { version = "1", features = ["derive"] }

--- a/racer-tracer/src/key_inputs.rs
+++ b/racer-tracer/src/key_inputs.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use minifb::{Key, Window};
+use minifb::{Key, MouseButton, MouseMode, Window};
 use slog::Logger;
 
 use crate::error::TracerError;
@@ -11,11 +11,17 @@ pub enum KeyEvent {
 }
 
 type Callback<'func> = Box<dyn Fn(f64) -> Result<(), TracerError> + Send + Sync + 'func>;
+pub type MouseCallback<'func> =
+    Box<dyn Fn(f32, f32) -> Result<(), TracerError> + Send + Sync + 'func>;
 pub type KeyCallback<'func> = (KeyEvent, Key, Callback<'func>);
 pub struct KeyInputs<'func> {
     is_down_callbacks: HashMap<Key, Vec<Callback<'func>>>,
     is_released_callbacks: HashMap<Key, Vec<Callback<'func>>>,
+    mouse_move_callbacks: Vec<MouseCallback<'func>>,
     log: Logger,
+    mouse_x: f32,
+    mouse_y: f32,
+    mouse_down: bool,
 }
 
 impl<'func, 'window> KeyInputs<'func> {
@@ -23,8 +29,19 @@ impl<'func, 'window> KeyInputs<'func> {
         KeyInputs {
             is_down_callbacks: HashMap::new(),
             is_released_callbacks: HashMap::new(),
+            mouse_move_callbacks: Vec::new(),
             log,
+            mouse_x: 0.0,
+            mouse_y: 0.0,
+            mouse_down: false,
         }
+    }
+
+    pub fn mouse_move(
+        &mut self,
+        callback: impl Fn(f32, f32) -> Result<(), TracerError> + Send + Sync + 'func,
+    ) {
+        self.mouse_move_callbacks.push(Box::new(callback));
     }
 
     pub fn input(
@@ -74,26 +91,48 @@ impl<'func, 'window> KeyInputs<'func> {
         callbacks.push(Box::new(closure));
     }
 
-    pub fn update(&self, window: &'window Window, dt: f64) {
-        self.is_down_callbacks
-            .iter()
-            .filter(|(key, _callbacks)| window.is_key_down(**key))
-            .for_each(|(_key, callbacks)| {
-                callbacks.iter().for_each(|callback| {
-                    if let Err(e) = callback(dt) {
-                        error!(self.log, "Key callback error: {}", e);
+    pub fn update(&mut self, window: &'window mut Window, dt: f64) {
+        if window.is_active() {
+            if window.get_mouse_down(MouseButton::Left) {
+                if let Some((x, y)) = window.get_mouse_pos(MouseMode::Pass) {
+                    if !self.mouse_down {
+                        self.mouse_x = x;
+                        self.mouse_y = y;
                     }
-                })
-            });
-        self.is_released_callbacks
-            .iter()
-            .filter(|(key, _callbacks)| window.is_key_released(**key))
-            .for_each(|(_key, callbacks)| {
-                callbacks.iter().for_each(|callback| {
-                    if let Err(e) = callback(dt) {
-                        error!(self.log, "Key callback error: {}", e);
-                    }
-                })
-            });
+                    self.mouse_move_callbacks.iter().for_each(|cb| {
+                        if let Err(e) = cb(self.mouse_x - x, self.mouse_y - y) {
+                            error!(self.log, "Mouse callback error: {}", e);
+                        }
+                    });
+                    self.mouse_x = x;
+                    self.mouse_y = y;
+                }
+
+                self.mouse_down = true;
+            } else {
+                self.mouse_down = false;
+            }
+
+            self.is_down_callbacks
+                .iter()
+                .filter(|(key, _callbacks)| window.is_key_down(**key))
+                .for_each(|(_key, callbacks)| {
+                    callbacks.iter().for_each(|callback| {
+                        if let Err(e) = callback(dt) {
+                            error!(self.log, "Key callback error: {}", e);
+                        }
+                    })
+                });
+            self.is_released_callbacks
+                .iter()
+                .filter(|(key, _callbacks)| window.is_key_released(**key))
+                .for_each(|(_key, callbacks)| {
+                    callbacks.iter().for_each(|callback| {
+                        if let Err(e) = callback(dt) {
+                            error!(self.log, "Key callback error: {}", e);
+                        }
+                    })
+                });
+        }
     }
 }

--- a/racer-tracer/src/scene_controller.rs
+++ b/racer-tracer/src/scene_controller.rs
@@ -3,8 +3,13 @@ pub mod interactive;
 use slog::Logger;
 
 use crate::{
-    camera::Camera, config::Config, error::TracerError, image::Image, key_inputs::KeyCallback,
-    scene::Scene, terminal::Terminal,
+    camera::Camera,
+    config::Config,
+    error::TracerError,
+    image::Image,
+    key_inputs::{KeyCallback, MouseCallback},
+    scene::Scene,
+    terminal::Terminal,
 };
 
 pub fn create_screen_buffer(image: &Image) -> Vec<u32> {
@@ -23,7 +28,9 @@ pub struct SceneData {
 pub trait SceneController: Send + Sync {
     // Return a vector of key callbacks. The provided closure will be
     // called when the corresponding key is release/pressed.
-    fn get_inputs(&self) -> Vec<KeyCallback>;
+    fn key_inputs(&self) -> Vec<KeyCallback>;
+
+    fn mouse_input(&self) -> Option<MouseCallback>;
 
     // Render function
     fn render(&self) -> Result<(), TracerError>;

--- a/racer-tracer/src/vec3.rs
+++ b/racer-tracer/src/vec3.rs
@@ -1,3 +1,6 @@
+//TODO: Replace this with glam.
+use glam::f32::Vec3 as FVec3;
+
 use std::{fmt, ops};
 
 use serde::Deserialize;
@@ -323,6 +326,22 @@ impl fmt::Display for Vec3 {
             )
             .as_str(),
         )
+    }
+}
+
+impl From<FVec3> for Vec3 {
+    fn from(v: FVec3) -> Self {
+        Vec3::new(v.x as f64, v.y as f64, v.z as f64)
+    }
+}
+
+impl From<Vec3> for FVec3 {
+    fn from(v: Vec3) -> Self {
+        FVec3 {
+            x: v.data[0] as f32,
+            y: v.data[1] as f32,
+            z: v.data[2] as f32,
+        }
     }
 }
 


### PR DESCRIPTION
Before you could only move the position of the camera.

- Add support for turning camera by holding down left mouse.
- Add support for turning camera with arrow keys.
- Add Mouse move callback for key_inputs.