### PR TITLE
✨ Add BVH solution to scene

### DIFF
--- a/racer-tracer/Cargo.toml
+++ b/racer-tracer/Cargo.toml
@@ -20,4 +20,7 @@ slog-term = "2"
 slog = "2"
 slog-async = "2"
 console = "0.15"
+mpsc = "0.1.0"
+bus = "2.4.0"
+dyn-clone = "1.0.11"
 serde = { version = "1", features = ["derive"] }

--- a/racer-tracer/config.yml
+++ b/racer-tracer/config.yml
@@ -1,7 +1,7 @@
 preview:
   samples: 2
   max_depth: 4
-  scale: 2
+  scale: 4
   num_threads_width: 10
   num_threads_height: 10
 

--- a/racer-tracer/src/aabb.rs
+++ b/racer-tracer/src/aabb.rs
@@ -1,0 +1,109 @@
+use crate::{ray::Ray, vec3::Vec3};
+
+#[derive(Clone, Default)]
+pub struct Aabb {
+    minimum: Vec3,
+    maximum: Vec3,
+}
+
+impl Aabb {
+    pub fn new(vec_a: Vec3, vec_b: Vec3) -> Self {
+        // People can do weird things (speaking of myself) such as
+        // spheres with negative radius etc. Just doing this to be
+        // really nice.
+        let minimum = Vec3::new(
+            vec_a.x().min(*vec_b.x()),
+            vec_a.y().min(*vec_b.y()),
+            vec_a.z().min(*vec_b.z()),
+        );
+        let maximum = Vec3::new(
+            vec_a.x().max(*vec_b.x()),
+            vec_a.y().max(*vec_b.y()),
+            vec_a.z().max(*vec_b.z()),
+        );
+
+        Self { minimum, maximum }
+    }
+
+    pub fn min(&self) -> &Vec3 {
+        &self.minimum
+    }
+
+    pub fn max(&self) -> &Vec3 {
+        &self.maximum
+    }
+
+    // Fastest
+    pub fn hit(&self, ray: &Ray, t_min: f64, t_max: f64) -> bool {
+        for a in 0..3 {
+            let inv_d = 1.0 / ray.direction()[a];
+            let mut t0 = (self.minimum[a] - ray.origin()[a]) * inv_d;
+            let mut t1 = (self.maximum[a] - ray.origin()[a]) * inv_d;
+            if inv_d < 0.0 {
+                std::mem::swap(&mut t0, &mut t1);
+            }
+
+            let min = if t0 > t_min { t0 } else { t_min };
+            let max = if t1 < t_max { t1 } else { t_max };
+
+            if max <= min {
+                return false;
+            }
+        }
+        true
+    }
+
+    // Faster
+    pub fn hit_b(&self, ray: &Ray, t_min: f64, t_max: f64) -> bool {
+        for a in 0..3 {
+            let inv_d = 1.0 / ray.direction()[a];
+            let mut t0 = (self.minimum[a] - ray.origin()[a]) * inv_d;
+            let mut t1 = (self.maximum[a] - ray.origin()[a]) * inv_d;
+            if inv_d < 0.0 {
+                std::mem::swap(&mut t0, &mut t1);
+            }
+            if t1.min(t_max) <= t0.max(t_min) {
+                return false;
+            }
+        }
+        true
+    }
+
+    // Slow
+    pub fn hit_c(&self, ray: &Ray, t_min: f64, t_max: f64) -> bool {
+        for a in 0..3 {
+            let va = (self.minimum[a] - ray.origin()[a]) / ray.direction()[a];
+            let vb = (self.maximum[a] - ray.origin()[a]) / ray.direction()[a];
+            let t0: f64 = va.min(vb);
+            let t1: f64 = va.max(vb);
+            let min = t0.min(t_min);
+            let max = t1.max(t_max);
+
+            if max <= min {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl From<(&Aabb, &Aabb)> for Aabb {
+    fn from((box_a, box_b): (&Aabb, &Aabb)) -> Self {
+        let mina = box_a.min();
+        let maxa = box_a.max();
+        let minb = box_b.min();
+        let maxb = box_b.max();
+        Aabb {
+            minimum: Vec3::new(
+                mina[0].min(minb[0]),
+                mina[1].min(minb[1]),
+                mina[2].min(minb[2]),
+            ),
+            maximum: Vec3::new(
+                maxa[0].max(maxb[0]),
+                maxa[1].max(maxb[1]),
+                maxa[2].max(maxb[2]),
+            ),
+        }
+    }
+}

--- a/racer-tracer/src/bvh_node.rs
+++ b/racer-tracer/src/bvh_node.rs
@@ -1,0 +1,214 @@
+use crate::{
+    aabb::Aabb,
+    data_bus::DataReader,
+    error::TracerError,
+    geometry::Hittable,
+    scene::{SceneObject, SceneObjectEvent},
+    util::random_int_range,
+};
+
+pub enum Node {
+    Leaf {
+        obj: SceneObject,
+    },
+    Inner {
+        left: Box<Node>,
+        right: Box<Node>,
+        aabb: Aabb,
+    },
+}
+
+// Currently clones everything which works but is bad. Would need an
+// implementation that is a bit more robust that supports taking out
+// an element and let it trickle down through the structure again.
+// Every time an object moves this will have to be re-computed which
+// is the bad part apart from the cloning. Will leave this for later
+// since the goal is to produce an image(s) and not a real time
+// experience first hand.
+//
+// Note to self: axis aligned could be an idea.
+impl Node {
+    fn build(mut objects: Vec<&SceneObject>, time_a: f64, time_b: f64) -> Node {
+        let axis = random_int_range(0, 2);
+        let comparator = if axis == 0 {
+            Node::box_x_compare
+        } else if axis == 1 {
+            Node::box_y_compare
+        } else {
+            Node::box_z_compare
+        };
+
+        let object_span = objects.len();
+        if object_span == 1 {
+            Node::Leaf {
+                obj: objects[0].clone(),
+            }
+        } else if object_span == 2 {
+            let (left_index, right_index) = if comparator(objects[0], objects[1]) {
+                (0, 1)
+            } else {
+                (1, 0)
+            };
+
+            Node::Inner {
+                left: Box::new(Node::Leaf {
+                    obj: objects[left_index].clone(),
+                }),
+                right: Box::new(Node::Leaf {
+                    obj: objects[right_index].clone(),
+                }),
+                aabb: (
+                    objects[left_index].bounding_box(time_a, time_b),
+                    objects[right_index].bounding_box(time_a, time_b),
+                )
+                    .into(),
+            }
+        } else {
+            objects.sort_by(|a, b| match comparator(a, b) {
+                true => std::cmp::Ordering::Less,
+                false => std::cmp::Ordering::Greater,
+            });
+            let mid = object_span / 2;
+            let left = Node::build(objects[0..mid].to_vec(), time_a, time_b);
+            let right = Node::build(objects[mid..].to_vec(), time_a, time_b);
+            let aabb: Aabb = (&Aabb::from(&left), &Aabb::from(&right)).into();
+
+            Node::Inner {
+                left: Box::new(left),
+                right: Box::new(right),
+                aabb,
+            }
+        }
+    }
+
+    fn box_compare(a: &SceneObject, b: &SceneObject, axis: usize) -> bool {
+        let box_a = a.bounding_box(0.0, 0.0);
+        let box_b = b.bounding_box(0.0, 0.0);
+        box_a.min()[axis] < box_b.min()[axis]
+    }
+
+    fn box_x_compare(a: &SceneObject, b: &SceneObject) -> bool {
+        Self::box_compare(a, b, 0)
+    }
+
+    fn box_y_compare(a: &SceneObject, b: &SceneObject) -> bool {
+        Self::box_compare(a, b, 1)
+    }
+
+    fn box_z_compare(a: &SceneObject, b: &SceneObject) -> bool {
+        Self::box_compare(a, b, 2)
+    }
+}
+
+impl From<&Node> for Aabb {
+    fn from(n: &Node) -> Self {
+        match n {
+            Node::Leaf { obj } => obj.bounding_box(0.0, 1.0).clone(),
+            Node::Inner { aabb, .. } => aabb.clone(),
+        }
+    }
+}
+
+impl Hittable for Node {
+    fn hit(
+        &self,
+        ray: &crate::ray::Ray,
+        t_min: f64,
+        t_max: f64,
+    ) -> Option<crate::geometry::HitRecord> {
+        if !self.bounding_box(t_min, t_max).hit(ray, t_min, t_max) {
+            return None;
+        }
+        match self {
+            Node::Leaf { obj } => obj.hit(ray, t_min, t_max),
+            Node::Inner { left, right, .. } => match left.hit(ray, t_min, t_max) {
+                Some(r) => match right.hit(ray, t_min, r.t) {
+                    Some(r2) => Some(r2),
+                    None => Some(r),
+                },
+                None => right.hit(ray, t_min, t_max),
+            },
+        }
+    }
+
+    fn bounding_box(&self, time_a: f64, time_b: f64) -> &Aabb {
+        match self {
+            Node::Leaf { obj } => obj.bounding_box(time_a, time_b),
+            Node::Inner { aabb, .. } => aabb,
+        }
+    }
+}
+
+pub struct BoundingVolumeHirearchy {
+    reader: DataReader<SceneObjectEvent>,
+    objects: Vec<SceneObject>,
+    node: Node,
+    time_a: f64,
+    time_b: f64,
+}
+
+impl BoundingVolumeHirearchy {
+    pub fn new(
+        objects: Vec<SceneObject>,
+        reader: DataReader<SceneObjectEvent>,
+        time_a: f64,
+        time_b: f64,
+    ) -> Self {
+        Self {
+            reader,
+            node: Node::build(
+                objects.iter().collect::<Vec<&SceneObject>>(),
+                time_a,
+                time_b,
+            ),
+            objects,
+            time_a,
+            time_b,
+        }
+    }
+
+    pub fn update(&mut self) -> Result<(), TracerError> {
+        let mut changed = false;
+        let res = self.reader.get_messages().and_then(|messages| {
+            messages.into_iter().try_for_each(|action| match action {
+                SceneObjectEvent::Remove { id } => {
+                    changed = true;
+                    self.objects.remove(id.id);
+                    Ok(())
+                }
+                SceneObjectEvent::Pos { id, pos } => {
+                    changed = true;
+                    if let Some(obj) = self.objects.get_mut(id.id) {
+                        obj.set_pos(pos);
+                    }
+                    Ok(())
+                }
+            })
+        });
+
+        if changed {
+            self.node = Node::build(
+                self.objects.iter().collect::<Vec<&SceneObject>>(),
+                self.time_a,
+                self.time_b,
+            );
+        }
+
+        res
+    }
+}
+
+impl Hittable for BoundingVolumeHirearchy {
+    fn hit(
+        &self,
+        ray: &crate::ray::Ray,
+        t_min: f64,
+        t_max: f64,
+    ) -> Option<crate::geometry::HitRecord> {
+        self.node.hit(ray, t_min, t_max)
+    }
+
+    fn bounding_box(&self, time_a: f64, time_b: f64) -> &Aabb {
+        self.node.bounding_box(time_a, time_b)
+    }
+}

--- a/racer-tracer/src/camera.rs
+++ b/racer-tracer/src/camera.rs
@@ -1,157 +1,375 @@
-use crate::config::CameraConfig;
+use crate::data_bus::{DataBus, DataReader, DataWriter};
+use crate::error::TracerError;
 use crate::image::Image;
 use crate::ray::Ray;
-use crate::util::{degrees_to_radians, random_in_unit_disk};
+use crate::util::{degrees_to_radians, random_double_range, random_in_unit_disk};
 use crate::vec3::Vec3;
 
 #[derive(Clone)]
-pub struct Camera {
-    pub viewport_height: f64,
-    pub viewport_width: f64,
-    pub origin: Vec3,
-    pub horizontal: Vec3,
-    pub vertical: Vec3,
-    pub upper_left_corner: Vec3,
-    pub forward: Vec3,
-    pub right: Vec3,
-    pub up: Vec3,
+#[allow(dead_code)]
+pub enum CameraEvent {
+    Pos {
+        origin: Vec3,
+        upper_left_corner: Vec3,
+    },
+    LookAt {
+        forward: Vec3,
+        right: Vec3,
+        up: Vec3,
+        horizontal: Vec3,
+        vertical: Vec3,
+        upper_left_corner: Vec3,
+    },
+    Vfov {
+        vfov: f64,
+        viewport_height: f64,
+        viewport_width: f64,
+        horizontal: Vec3,
+        vertical: Vec3,
+        upper_left_corner: Vec3,
+    },
+    Aperture {
+        lens_radius: f64,
+    },
+    FocusDistance {
+        focus_distance: f64,
+        horizontal: Vec3,
+        vertical: Vec3,
+        upper_left_corner: Vec3,
+    },
+    Rotate {
+        forward: Vec3,
+        right: Vec3,
+        up: Vec3,
+        vertical: Vec3,
+        horizontal: Vec3,
+        upper_left_corner: Vec3,
+    },
+}
+
+pub struct SharedCamera {
+    reader: DataReader<CameraEvent>,
+    data: CameraSharedData,
+}
+
+#[derive(Clone)]
+pub struct CameraSharedData {
+    origin: Vec3,
+    upper_left_corner: Vec3,
+    forward: Vec3,
+    right: Vec3,
+    up: Vec3,
+    horizontal: Vec3,
+    vertical: Vec3,
+    vfov: f64,
+    viewport_width: f64,
+    viewport_height: f64,
+    lens_radius: f64,
+    focus_distance: f64,
+    time_a: f64,
+    time_b: f64,
+}
+
+impl SharedCamera {
+    pub fn new(data: CameraSharedData, reader: DataReader<CameraEvent>) -> Self {
+        Self { reader, data }
+    }
+
+    pub fn data(&self) -> &CameraSharedData {
+        &self.data
+    }
+
+    pub fn update(&mut self) -> Result<(), TracerError> {
+        self.reader.get_messages().map(|messages| {
+            messages.into_iter().for_each(|action| {
+                match action {
+                    CameraEvent::Pos {
+                        origin,
+                        upper_left_corner,
+                    } => {
+                        self.data.origin = origin;
+                        self.data.upper_left_corner = upper_left_corner;
+                    }
+                    CameraEvent::LookAt {
+                        forward,
+                        right,
+                        up,
+                        horizontal,
+                        vertical,
+                        upper_left_corner,
+                    } => {
+                        self.data.forward = forward;
+                        self.data.right = right;
+                        self.data.up = up;
+                        self.data.horizontal = horizontal;
+                        self.data.vertical = vertical;
+                        self.data.upper_left_corner = upper_left_corner;
+                    }
+                    CameraEvent::Vfov {
+                        vfov,
+                        viewport_height,
+                        viewport_width,
+                        horizontal,
+                        vertical,
+                        upper_left_corner,
+                    } => {
+                        self.data.vfov = vfov;
+                        self.data.viewport_height = viewport_height;
+                        self.data.viewport_width = viewport_width;
+                        self.data.horizontal = horizontal;
+                        self.data.vertical = vertical;
+                        self.data.upper_left_corner = upper_left_corner;
+                    }
+                    CameraEvent::Aperture { lens_radius } => {
+                        self.data.lens_radius = lens_radius;
+                    }
+                    CameraEvent::FocusDistance {
+                        focus_distance,
+                        horizontal,
+                        vertical,
+                        upper_left_corner,
+                    } => {
+                        self.data.focus_distance = focus_distance;
+                        self.data.horizontal = horizontal;
+                        self.data.vertical = vertical;
+                        self.data.upper_left_corner = upper_left_corner;
+                    }
+                    CameraEvent::Rotate {
+                        forward,
+                        right,
+                        up,
+                        vertical,
+                        horizontal,
+                        upper_left_corner,
+                    } => {
+                        self.data.forward = forward;
+                        self.data.right = right;
+                        self.data.up = up;
+                        self.data.vertical = vertical;
+                        self.data.horizontal = horizontal;
+                        self.data.upper_left_corner = upper_left_corner;
+                    }
+                };
+            });
+        })
+    }
+}
+
+pub struct CameraInitData {
+    pub look_from: Vec3,
+    pub look_at: Vec3,
     pub scene_up: Vec3,
-    pub lens_radius: f64,
+    pub vfov: f64,
+    pub aperture: f64,
     pub focus_distance: f64,
     pub aspect_ratio: f64,
+    pub time_a: f64,
+    pub time_b: f64,
+}
+
+pub struct Camera {
+    bus: DataBus<CameraEvent>,
+    writer: DataWriter<CameraEvent>,
+    data: CameraSharedData,
+    scene_up: Vec3,
+    aspect_ratio: f64,
+    aperture: f64,
 }
 
 impl Camera {
-    pub fn new(
-        look_from: Vec3,
-        look_at: Vec3,
-        scene_up: Vec3,
-        vfov: f64,
-        image: &Image,
-        aperture: f64,
-        focus_distance: f64,
-    ) -> Camera {
-        let h = (degrees_to_radians(vfov) / 2.0).tan();
+    pub fn new(init: CameraInitData, image: &Image) -> Self {
+        let h = (degrees_to_radians(init.vfov) / 2.0).tan();
         let viewport_height = 2.0 * h;
         let viewport_width = image.aspect_ratio * viewport_height;
 
-        let forward = (look_from - look_at).unit_vector();
-        let right = scene_up.cross(&forward).unit_vector();
+        let forward = (init.look_from - init.look_at).unit_vector();
+        let right = init.scene_up.cross(&forward).unit_vector();
         let up = forward.cross(&right);
 
-        let horizontal = focus_distance * viewport_width * right;
-        let vertical = focus_distance * viewport_height * up;
-        Camera {
-            viewport_height,
-            viewport_width,
-            origin: look_from,
-            horizontal,
-            vertical,
-            upper_left_corner: look_from + vertical / 2.0
-                - horizontal / 2.0
-                - focus_distance * forward,
-            forward,
-            right,
-            up,
-            scene_up,
-            lens_radius: aperture * 0.5,
-            focus_distance,
-            aspect_ratio: image.aspect_ratio,
+        let horizontal = init.focus_distance * viewport_width * right;
+        let vertical = init.focus_distance * viewport_height * up;
+
+        let bus = DataBus::<CameraEvent>::new("camera");
+        Self {
+            writer: bus.get_writer(),
+            bus,
+            data: CameraSharedData {
+                viewport_height,
+                viewport_width,
+                origin: init.look_from,
+                horizontal,
+                vertical,
+                upper_left_corner: init.look_from + vertical / 2.0
+                    - horizontal / 2.0
+                    - init.focus_distance * forward,
+                forward,
+                right,
+                up,
+                vfov: init.vfov,
+                lens_radius: init.aperture * 0.5,
+                focus_distance: init.focus_distance,
+                time_a: init.time_a,
+                time_b: init.time_b,
+            },
+            aspect_ratio: init.aspect_ratio,
+            scene_up: init.scene_up,
+            aperture: init.aperture,
         }
     }
 
-    pub fn set_pos(&mut self, pos: Vec3) {
-        self.origin = pos;
+    pub fn update(&mut self) -> Result<(), TracerError> {
+        self.bus.update()
+    }
+
+    pub fn get_shared_camera(&mut self) -> SharedCamera {
+        SharedCamera::new(self.data.clone(), self.bus.get_reader())
+    }
+
+    pub fn forward(&self) -> Vec3 {
+        self.data.forward
+    }
+
+    pub fn up(&self) -> Vec3 {
+        self.data.up
+    }
+
+    pub fn right(&self) -> Vec3 {
+        self.data.right
+    }
+
+    pub fn set_pos(&mut self, pos: Vec3) -> Result<(), TracerError> {
+        self.data.origin = pos;
         self.update_corner();
+        self.writer.write(CameraEvent::Pos {
+            origin: self.data.origin,
+            upper_left_corner: self.data.upper_left_corner,
+        })
     }
 
-    pub fn set_look_at(&mut self, look_at: Vec3) {
-        self.forward = (self.origin - look_at).unit_vector();
+    #[allow(dead_code)]
+    pub fn set_look_at(&mut self, look_at: Vec3) -> Result<(), TracerError> {
+        self.data.forward = (self.data.origin - look_at).unit_vector();
         self.update_directions();
+        self.writer.write(CameraEvent::LookAt {
+            forward: self.data.forward,
+            right: self.data.right,
+            up: self.data.up,
+            horizontal: self.data.horizontal,
+            vertical: self.data.vertical,
+            upper_left_corner: self.data.vertical,
+        })
     }
 
-    pub fn set_fov(&mut self, vfov: f64) {
-        let h = (degrees_to_radians(vfov) / 2.0).tan();
-        self.viewport_height = 2.0 * h;
-        self.viewport_width = self.aspect_ratio * self.viewport_height;
+    pub fn set_fov(&mut self, vfov: f64) -> Result<(), TracerError> {
+        self.data.vfov = vfov;
+        let h = (degrees_to_radians(self.data.vfov) / 2.0).tan();
+        self.data.viewport_height = 2.0 * h;
+        self.data.viewport_width = self.aspect_ratio * self.data.viewport_height;
         self.update_viewport();
+        self.writer.write(CameraEvent::Vfov {
+            vfov: self.data.vfov,
+            viewport_height: self.data.viewport_height,
+            viewport_width: self.data.viewport_width,
+            horizontal: self.data.horizontal,
+            vertical: self.data.vertical,
+            upper_left_corner: self.data.upper_left_corner,
+        })
     }
 
-    pub fn set_aperture(&mut self, aperture: f64) {
-        self.lens_radius = aperture * 0.5;
+    pub fn get_vfov(&self) -> f64 {
+        self.data.vfov
     }
 
-    pub fn set_focus_distance(&mut self, focus_distance: f64) {
-        self.focus_distance = focus_distance;
+    pub fn set_aperture(&mut self, aperture: f64) -> Result<(), TracerError> {
+        self.aperture = aperture;
+        self.data.lens_radius = self.aperture * 0.5;
+        self.writer.write(CameraEvent::Aperture {
+            lens_radius: self.data.lens_radius,
+        })
+    }
+
+    pub fn get_aperture(&self) -> f64 {
+        self.aperture
+    }
+
+    pub fn set_focus_distance(&mut self, focus_distance: f64) -> Result<(), TracerError> {
+        self.data.focus_distance = focus_distance;
         self.update_viewport();
+        self.writer.write(CameraEvent::FocusDistance {
+            focus_distance: self.data.focus_distance,
+            horizontal: self.data.horizontal,
+            vertical: self.data.vertical,
+            upper_left_corner: self.data.upper_left_corner,
+        })
     }
 
-    pub fn get_ray(&self, u: f64, v: f64) -> Ray {
-        let ray_direction = self.lens_radius * random_in_unit_disk();
-        let offset = self.right * ray_direction.x() + self.up * ray_direction.y();
+    pub fn get_focus_distance(&self) -> f64 {
+        self.data.focus_distance
+    }
+
+    pub fn get_ray(camera_data: &CameraSharedData, u: f64, v: f64) -> Ray {
+        let ray_direction = camera_data.lens_radius * random_in_unit_disk();
+        let offset = camera_data.right * ray_direction.x() + camera_data.up * ray_direction.y();
         Ray::new(
-            self.origin + offset,
-            self.upper_left_corner + u * self.horizontal - v * self.vertical - self.origin - offset,
+            camera_data.origin + offset,
+            camera_data.upper_left_corner + u * camera_data.horizontal
+                - v * camera_data.vertical
+                - camera_data.origin
+                - offset,
+            random_double_range(camera_data.time_a, camera_data.time_b),
         )
     }
 
-    pub fn go_forward(&mut self, go: f64) {
-        self.origin += self.forward * go;
-        self.update_corner()
+    pub fn go_forward(&mut self, go: f64) -> Result<(), TracerError> {
+        self.set_pos(self.data.origin + self.data.forward * go)
     }
 
-    pub fn go_right(&mut self, go: f64) {
-        self.origin += self.right * go;
-        self.update_corner()
+    pub fn go_right(&mut self, go: f64) -> Result<(), TracerError> {
+        self.set_pos(self.data.origin + self.data.right * go)
     }
 
-    pub fn rotate(&mut self, right_move: f64, up_move: f64) {
-        self.forward.rotate(up_move, &self.right);
-        self.forward.rotate(right_move, &self.scene_up);
+    pub fn rotate(&mut self, right_move: f64, up_move: f64) -> Result<(), TracerError> {
+        self.data.forward.rotate(up_move, &self.data.right);
+        self.data.forward.rotate(right_move, &self.scene_up);
         self.update_directions();
         self.update_corner();
+        self.writer.write(CameraEvent::Rotate {
+            forward: self.data.forward,
+            right: self.data.right,
+            up: self.data.up,
+            vertical: self.data.vertical,
+            horizontal: self.data.horizontal,
+            upper_left_corner: self.data.upper_left_corner,
+        })
     }
 
-    pub fn rotate_up(&mut self, degrees: f64) {
-        self.forward.rotate(degrees, &self.right);
-        self.update_directions();
+    #[allow(dead_code)]
+    pub fn rotate_right(&mut self, right_move: f64) -> Result<(), TracerError> {
+        self.rotate(right_move, 0.0)
     }
 
-    pub fn rotate_right(&mut self, degrees: f64) {
-        self.forward.rotate(degrees, &self.scene_up);
-        self.update_directions();
+    #[allow(dead_code)]
+    pub fn rotate_up(&mut self, up_move: f64) -> Result<(), TracerError> {
+        self.rotate(0.0, up_move)
     }
 
     fn update_directions(&mut self) {
-        self.forward.unit_vector();
-        self.right = self.scene_up.cross(&self.forward).unit_vector();
-        self.up = self.forward.cross(&self.right);
+        self.data.forward.unit_vector();
+        self.data.right = self.scene_up.cross(&self.data.forward).unit_vector();
+        self.data.up = self.data.forward.cross(&self.data.right);
         self.update_viewport();
     }
 
     fn update_viewport(&mut self) {
-        self.horizontal = self.focus_distance * self.viewport_width * self.right;
-        self.vertical = self.focus_distance * self.viewport_height * self.up;
+        self.data.horizontal =
+            self.data.focus_distance * self.data.viewport_width * self.data.right;
+        self.data.vertical = self.data.focus_distance * self.data.viewport_height * self.data.up;
         self.update_corner()
     }
 
     fn update_corner(&mut self) {
-        self.upper_left_corner = self.origin + self.vertical / 2.0
-            - self.horizontal / 2.0
-            - self.focus_distance * self.forward;
-    }
-}
-
-impl From<(&Image, &CameraConfig)> for Camera {
-    fn from((image, c): (&Image, &CameraConfig)) -> Self {
-        Self::new(
-            c.pos,
-            c.look_at,
-            Vec3::new(0.0, 1.0, 0.0),
-            c.vfov,
-            image,
-            c.aperture,
-            c.focus_distance,
-        )
+        self.data.upper_left_corner = self.data.origin + self.data.vertical / 2.0
+            - self.data.horizontal / 2.0
+            - self.data.focus_distance * self.data.forward;
     }
 }

--- a/racer-tracer/src/data_bus.rs
+++ b/racer-tracer/src/data_bus.rs
@@ -1,0 +1,129 @@
+use std::{
+    sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender},
+    time::Duration,
+};
+
+use bus::{Bus, BusReader};
+
+use crate::error::TracerError;
+
+pub struct DataWriter<T> {
+    channel_name: String,
+    sender: Sender<T>,
+}
+
+impl<T> DataWriter<T> {
+    fn new(channel_name: String, sender: Sender<T>) -> Self {
+        Self {
+            channel_name,
+            sender,
+        }
+    }
+
+    pub fn write(&self, action: T) -> Result<(), TracerError> {
+        self.sender
+            .send(action)
+            .map_err(|e| TracerError::BusWriteError(self.channel_name.clone(), e.to_string()))
+    }
+}
+
+pub struct DataReader<T: Clone + Sync> {
+    channel_name: String,
+    reader: BusReader<T>,
+}
+
+impl<T: Clone + Sync> DataReader<T> {
+    fn new(channel_name: String, reader: BusReader<T>) -> Self {
+        Self {
+            channel_name,
+            reader,
+        }
+    }
+
+    pub fn get_messages(&mut self) -> Result<Vec<T>, TracerError> {
+        // Note: This does not block or suspend which can be nice?
+        // Can also not be nice since it's never suspending the thread
+        // implicitly creating a busy update loop where nothing
+        // actually happens.
+        // Probably better to make it blocking, ie. suspend the thread
+        // until something actually happens. Will look into this later.
+
+        // TODO: This code could possible be expressed in a nicer manner.
+        let mut buf: Vec<T> = vec![];
+        let mut res = self.reader.recv_timeout(Duration::from_millis(0));
+        while let Ok(action) = res {
+            buf.push(action);
+            res = self.reader.recv_timeout(Duration::from_millis(0));
+        }
+
+        match res {
+            Ok(_) => Ok(buf),
+            Err(e) if e == RecvTimeoutError::Timeout => Ok(buf),
+            Err(e) => Err(TracerError::BusReadError(
+                self.channel_name.clone(),
+                e.to_string(),
+            )),
+        }
+    }
+}
+
+pub struct DataBus<T: Clone + Sync> {
+    channel_name: String,
+    receiver: Receiver<T>,
+    bus: Bus<T>,
+    data_writer: Sender<T>,
+}
+
+impl<T: Clone + Sync> DataBus<T> {
+    pub fn new<U: AsRef<str>>(channel_name: U) -> Self {
+        let (sender, receiver) = channel();
+        Self {
+            channel_name: channel_name.as_ref().to_string(),
+            receiver,
+            data_writer: sender,
+            bus: Bus::new(1024),
+        }
+    }
+
+    pub fn update(&mut self) -> Result<(), TracerError> {
+        let mut res: Result<T, TracerError> = self
+            .receiver
+            .recv_timeout(Duration::from_millis(0))
+            .map_err(|e| e.into());
+
+        while let Ok(action) = res {
+            res = self
+                .bus
+                .try_broadcast(action)
+                .map_err(|_| TracerError::BusUpdateError(self.channel_name.clone()))
+                .and_then(|_| {
+                    self.receiver
+                        .recv_timeout(Duration::from_millis(0))
+                        .map_err(|e| e.into())
+                });
+        }
+
+        match res {
+            Ok(_) => Ok(()),
+            Err(e) if e == TracerError::BusTimeoutError() => Ok(()),
+            Err(e) => Err(TracerError::RecieveError(e.to_string())),
+        }
+    }
+
+    pub fn get_reader(&mut self) -> DataReader<T> {
+        DataReader::new(self.channel_name.clone(), self.bus.add_rx())
+    }
+
+    pub fn get_writer(&self) -> DataWriter<T> {
+        DataWriter::new(self.channel_name.clone(), self.data_writer.clone())
+    }
+}
+
+impl From<RecvTimeoutError> for TracerError {
+    fn from(e: RecvTimeoutError) -> Self {
+        match e {
+            RecvTimeoutError::Timeout => TracerError::BusTimeoutError(),
+            RecvTimeoutError::Disconnected => TracerError::BusUpdateError(e.to_string()),
+        }
+    }
+}

--- a/racer-tracer/src/error.rs
+++ b/racer-tracer/src/error.rs
@@ -37,6 +37,30 @@ pub enum TracerError {
 
     #[error("Failed to create log: {0}")]
     CreateLogError(String),
+
+    #[error("Failed to recieve data: {0}")]
+    RecieveError(String),
+
+    #[error("Failed to recieve data: {0}")]
+    SendError(String),
+
+    #[error("Action protocol error! Unsupported action for: {0}")]
+    ActionProtocolError(String),
+
+    #[error("Failed to write data to bus \"{0}\": {1}")]
+    BusWriteError(String, String),
+
+    #[error("Failed to write data to bus \"{0}\": {1}")]
+    BusReadError(String, String),
+
+    #[error("Failed to write data to bus: {0}")]
+    BusUpdateError(String),
+
+    #[error("Bus timeout error.")]
+    BusTimeoutError(),
+
+    #[error("No object with id: {0}.")]
+    NoObjectWithId(usize),
 }
 
 impl From<TracerError> for i32 {
@@ -54,6 +78,14 @@ impl From<TracerError> for i32 {
             TracerError::ArgumentParsingError(_) => 10,
             TracerError::KeyError(_) => 11,
             TracerError::CreateLogError(_) => 12,
+            TracerError::RecieveError(_) => 13,
+            TracerError::SendError(_) => 14,
+            TracerError::ActionProtocolError(_) => 15,
+            TracerError::BusWriteError(_, _) => 16,
+            TracerError::BusReadError(_, _) => 17,
+            TracerError::BusUpdateError(_) => 18,
+            TracerError::BusTimeoutError() => 19,
+            TracerError::NoObjectWithId(_) => 20,
         }
     }
 }

--- a/racer-tracer/src/geometry.rs
+++ b/racer-tracer/src/geometry.rs
@@ -1,7 +1,9 @@
+pub mod moving_sphere;
 pub mod sphere;
 
 use std::sync::Arc;
 
+use crate::aabb::Aabb;
 use crate::material::Material;
 use crate::ray::Ray;
 use crate::vec3::Vec3;
@@ -11,11 +13,11 @@ pub struct HitRecord {
     pub normal: Vec3,
     pub t: f64,
     pub front_face: bool,
-    pub material: Arc<Box<dyn Material>>,
+    pub material: Arc<dyn Material>,
 }
 
 impl HitRecord {
-    fn new(point: Vec3, t: f64, material: Arc<Box<dyn Material>>) -> Self {
+    fn new(point: Vec3, t: f64, material: Arc<dyn Material>) -> Self {
         Self {
             point,
             normal: Vec3::default(),
@@ -36,6 +38,7 @@ impl HitRecord {
 }
 
 pub trait Hittable: Send + Sync {
-    //pub trait Hittable {
     fn hit(&self, ray: &Ray, t_min: f64, t_max: f64) -> Option<HitRecord>;
+
+    fn bounding_box(&self, time_a: f64, time_b: f64) -> &Aabb;
 }

--- a/racer-tracer/src/geometry/moving_sphere.rs
+++ b/racer-tracer/src/geometry/moving_sphere.rs
@@ -1,0 +1,92 @@
+use std::option::Option;
+use std::sync::Arc;
+
+use crate::aabb::Aabb;
+use crate::geometry::HitRecord;
+use crate::ray::Ray;
+use crate::scene::{HittableSceneObject, SceneObject};
+use crate::vec3::Vec3;
+
+// TODO: I really do not like these moving spheres. They add the time
+// functionality which expands throughout the code base. It's sort of
+// a hack to make a still image look like it's moving in the first
+// place. It's only used by a single geometry. It adds more crap
+// than it's worth. The second you add keyframes to this it would be
+// redundant. The blur should be based on the velocity if
+// anything. Keeping it for now...
+#[derive(Clone)]
+pub struct MovingSphere {
+    pos_a: Vec3,
+    pos_b: Vec3,
+    radius: f64,
+    time_a: f64,
+    time_b: f64,
+    aabb: Aabb,
+}
+
+impl MovingSphere {
+    pub fn new(pos_a: Vec3, pos_b: Vec3, radius: f64, time_a: f64, time_b: f64) -> Self {
+        Self {
+            pos_a,
+            pos_b,
+            radius,
+            time_a,
+            time_b,
+            aabb: (
+                &Aabb::new(
+                    pos_a - Vec3::new(radius, radius, radius),
+                    pos_a + Vec3::new(radius, radius, radius),
+                ),
+                &Aabb::new(
+                    pos_b - Vec3::new(radius, radius, radius),
+                    pos_b + Vec3::new(radius, radius, radius),
+                ),
+            )
+                .into(),
+        }
+    }
+}
+
+impl MovingSphere {
+    pub fn pos(&self, time: f64) -> Vec3 {
+        self.pos_a
+            + ((time - self.time_a) / (self.time_b - self.time_a)) * (self.pos_b - self.pos_a)
+    }
+}
+
+impl HittableSceneObject for MovingSphere {
+    fn obj_hit(&self, obj: &SceneObject, ray: &Ray, t_min: f64, t_max: f64) -> Option<HitRecord> {
+        let oc = ray.origin() - self.pos(ray.time());
+        let a = ray.direction().length_squared();
+        let half_b = oc.dot(ray.direction());
+        let c = oc.length_squared() - self.radius * self.radius;
+        let discriminant = half_b * half_b - a * c;
+
+        if discriminant < 0.0 {
+            return None;
+        }
+
+        let sqrtd = discriminant.sqrt();
+
+        // Find the nearest root that lies in acceptable range.
+        let mut root = (-half_b - sqrtd) / a;
+        if root < t_min || t_max < root {
+            root = (-half_b + sqrtd) / a;
+
+            if root < t_min || t_max < root {
+                return None;
+            }
+        }
+
+        let point = ray.at(root);
+        let outward_normal = (point - self.pos(ray.time())) / self.radius;
+
+        let mut hit_record = HitRecord::new(point, root, Arc::clone(&obj.material));
+        hit_record.set_face_normal(ray, outward_normal);
+        Some(hit_record)
+    }
+
+    fn bounding_box(&self, _time0: f64, _time1: f64) -> &Aabb {
+        &self.aabb
+    }
+}

--- a/racer-tracer/src/image.rs
+++ b/racer-tracer/src/image.rs
@@ -15,6 +15,12 @@ impl Image {
     }
 }
 
+impl Image {
+    pub fn screen_to_uv(&self, screen_x: f64, screen_y: f64) -> (f64, f64) {
+        (screen_x / self.width as f64, screen_y / self.height as f64)
+    }
+}
+
 pub struct SubImage {
     pub x: usize,
     pub y: usize,

--- a/racer-tracer/src/material.rs
+++ b/racer-tracer/src/material.rs
@@ -2,13 +2,9 @@ pub mod dialectric;
 pub mod lambertian;
 pub mod metal;
 
-use std::sync::Arc;
-
 use crate::geometry::HitRecord;
 use crate::ray::Ray;
 use crate::vec3::Color;
-
-pub type SharedMaterial = Arc<Box<dyn Material>>;
 
 pub trait Material: Send + Sync {
     fn scatter(&self, ray: &Ray, hit_record: &HitRecord) -> Option<(Ray, Color)>;

--- a/racer-tracer/src/material/dialectric.rs
+++ b/racer-tracer/src/material/dialectric.rs
@@ -48,6 +48,9 @@ impl Material for Dialectric {
             refract(unit_direction, &rec.normal, refraction_ratio)
         };
 
-        Some((Ray::new(rec.point, direction), Color::new(1.0, 1.0, 1.0)))
+        Some((
+            Ray::new(rec.point, direction, ray.time()),
+            Color::new(1.0, 1.0, 1.0),
+        ))
     }
 }

--- a/racer-tracer/src/material/lambertian.rs
+++ b/racer-tracer/src/material/lambertian.rs
@@ -17,7 +17,7 @@ impl Lambertian {
 impl Material for Lambertian {
     fn scatter(
         &self,
-        _ray: &crate::ray::Ray,
+        ray: &crate::ray::Ray,
         rec: &crate::geometry::HitRecord,
     ) -> Option<(Ray, Color)> {
         let mut scatter_direction = rec.normal + random_unit_vector();
@@ -27,6 +27,9 @@ impl Material for Lambertian {
             scatter_direction = rec.normal;
         }
 
-        Some((Ray::new(rec.point, scatter_direction), self.color))
+        Some((
+            Ray::new(rec.point, scatter_direction, ray.time()),
+            self.color,
+        ))
     }
 }

--- a/racer-tracer/src/material/metal.rs
+++ b/racer-tracer/src/material/metal.rs
@@ -22,7 +22,11 @@ impl Material for Metal {
         rec: &crate::geometry::HitRecord,
     ) -> Option<(Ray, Color)> {
         let reflected = reflect(&ray.direction().unit_vector(), &rec.normal);
-        let scattered = Ray::new(rec.point, reflected + self.fuzz * random_in_unit_sphere());
+        let scattered = Ray::new(
+            rec.point,
+            reflected + self.fuzz * random_in_unit_sphere(),
+            ray.time(),
+        );
 
         if scattered.direction().dot(&rec.normal) < 0.0 {
             None

--- a/racer-tracer/src/ray.rs
+++ b/racer-tracer/src/ray.rs
@@ -3,11 +3,16 @@ use crate::vec3::Vec3;
 pub struct Ray {
     origin: Vec3,
     direction: Vec3,
+    time: f64,
 }
 
 impl Ray {
-    pub fn new(origin: Vec3, direction: Vec3) -> Ray {
-        Ray { origin, direction }
+    pub fn new(origin: Vec3, direction: Vec3, time: f64) -> Ray {
+        Ray {
+            origin,
+            direction,
+            time,
+        }
     }
 
     pub fn origin(&self) -> &Vec3 {
@@ -16,6 +21,10 @@ impl Ray {
 
     pub fn direction(&self) -> &Vec3 {
         &self.direction
+    }
+
+    pub fn time(&self) -> f64 {
+        self.time
     }
 
     pub fn at(&self, go_length: f64) -> Vec3 {

--- a/racer-tracer/src/renderer.rs
+++ b/racer-tracer/src/renderer.rs
@@ -3,7 +3,7 @@ use std::{sync::RwLock, time::Duration};
 use synchronoise::SignalEvent;
 
 use crate::{
-    camera::Camera,
+    camera::CameraSharedData,
     config::{Config, Renderer as ConfigRenderer},
     error::TracerError,
     geometry::Hittable,
@@ -47,7 +47,7 @@ fn ray_color(scene: &dyn Hittable, ray: &Ray, depth: usize) -> Vec3 {
 
 pub struct RenderData<'a> {
     pub buffer: &'a RwLock<Vec<u32>>,
-    pub camera: &'a RwLock<Camera>,
+    pub camera_data: &'a CameraSharedData,
     pub image: &'a Image,
     pub scene: &'a dyn Hittable,
     pub config: &'a Config,

--- a/racer-tracer/src/scene.rs
+++ b/racer-tracer/src/scene.rs
@@ -2,53 +2,189 @@ pub mod none;
 pub mod random;
 pub mod yml;
 
+use dyn_clone::DynClone;
+use std::sync::Arc;
+
 use crate::{
-    config::SceneLoader as CSLoader, error::TracerError, geometry::Hittable,
-    scene::none::NoneLoader, scene::random::Random, scene::yml::YmlLoader,
+    aabb::Aabb,
+    camera::{Camera, SharedCamera},
+    data_bus::{DataBus, DataReader, DataWriter},
+    error::TracerError,
+    geometry::{moving_sphere::MovingSphere, sphere::Sphere, HitRecord, Hittable},
+    image::Image,
+    material::Material,
+    ray::Ray,
+    vec3::Vec3,
 };
 
-pub struct Scene {
-    objects: Vec<Box<dyn Hittable>>,
+pub trait HittableSceneObject: Send + Sync + DynClone {
+    fn obj_hit(&self, obj: &SceneObject, ray: &Ray, t_min: f64, t_max: f64) -> Option<HitRecord>;
+    fn bounding_box(&self, _time0: f64, _time1: f64) -> &Aabb;
 }
 
-impl Scene {
-    pub fn try_new(config_loader: &CSLoader) -> Result<Self, TracerError> {
-        let loader: Box<dyn SceneLoader> = match config_loader {
-            CSLoader::Yml { path } => Box::new(YmlLoader::new(path.clone())),
-            CSLoader::Random => Box::new(Random::new()),
-            CSLoader::None => Box::new(NoneLoader::new()),
-        };
+dyn_clone::clone_trait_object!(HittableSceneObject);
 
-        loader.load().map(|objects| Self { objects })
+#[derive(Clone)]
+pub struct SceneObject {
+    pub pos: Vec3,
+    pub aabb: Aabb,
+    pub material: Arc<dyn Material>,
+    pub hittable: Box<dyn HittableSceneObject>,
+}
+
+impl Hittable for SceneObject {
+    fn hit(&self, ray: &Ray, t_min: f64, t_max: f64) -> Option<HitRecord> {
+        self.hittable.obj_hit(self, ray, t_min, t_max)
     }
 
-    #[allow(dead_code)]
-    pub fn add(&mut self, hittable: Box<dyn Hittable>) {
-        self.objects.push(hittable);
+    fn bounding_box(&self, time_a: f64, time_b: f64) -> &Aabb {
+        self.hittable.bounding_box(time_a, time_b)
     }
 }
 
-impl Hittable for Scene {
-    fn hit(
-        &self,
-        ray: &crate::ray::Ray,
-        t_min: f64,
-        t_max: f64,
-    ) -> Option<crate::geometry::HitRecord> {
-        let mut rec = None;
-        let mut closes_so_far = t_max;
+pub fn create_sphere(pos: Vec3, material: Arc<dyn Material>, radius: f64) -> SceneObject {
+    let sphere = Sphere::new(&pos, radius);
+    SceneObject {
+        pos,
+        aabb: sphere.bounding_box(0.0, 0.0).clone(), // TODO: Time
+        material,
+        hittable: Box::new(sphere),
+    }
+}
 
-        for obj in self.objects.iter() {
-            if let Some(hit_rec) = obj.hit(ray, t_min, closes_so_far) {
-                closes_so_far = hit_rec.t;
-                rec = Some(hit_rec);
-            }
-        }
+pub fn create_movable_sphere(
+    pos_a: Vec3,
+    pos_b: Vec3,
+    material: Arc<dyn Material>,
+    radius: f64,
+    time_a: f64,
+    time_b: f64,
+) -> SceneObject {
+    let movable_sphere = MovingSphere::new(pos_a, pos_b, radius, time_a, time_b);
+    SceneObject {
+        pos: pos_a,
+        aabb: movable_sphere.bounding_box(time_a, time_b).clone(),
+        material,
+        hittable: Box::new(movable_sphere),
+    }
+}
 
-        rec
+impl SceneObject {
+    pub fn set_pos(&mut self, pos: Vec3) {
+        self.pos = pos;
+    }
+
+    pub fn pos(&self) -> Vec3 {
+        self.pos
+    }
+
+    pub fn aabb(&self) -> &Aabb {
+        &self.aabb
     }
 }
 
 pub trait SceneLoader: Send + Sync {
-    fn load(&self) -> Result<Vec<Box<dyn Hittable>>, TracerError>;
+    fn load(&self) -> Result<Vec<SceneObject>, TracerError>;
+}
+
+// Ensures objects are synced between update and render.
+#[derive(Eq, PartialEq, Hash, Clone, Copy)]
+pub struct ObjectCookie {
+    pub id: usize, // Should be private field
+}
+
+#[derive(Clone)]
+pub enum SceneObjectEvent {
+    Pos { id: ObjectCookie, pos: Vec3 },
+    Remove { id: ObjectCookie },
+    // TODO: Create events for creation of objects
+}
+
+pub struct Scene {
+    objects: Vec<SceneObject>,
+    bus: DataBus<SceneObjectEvent>,
+    writer: DataWriter<SceneObjectEvent>,
+    camera: SharedCamera,
+    selected_object: Option<ObjectCookie>,
+    image: Image,
+}
+
+// Note: Does not support inserting objects after creation.
+// Will fix that at a later point.
+impl Scene {
+    pub fn new(camera: SharedCamera, image: Image, objects: Vec<SceneObject>) -> Self {
+        let bus = DataBus::new("scene-object-handler");
+        Scene {
+            objects,
+            writer: bus.get_writer(),
+            bus,
+            camera,
+            image,
+            selected_object: None,
+        }
+    }
+
+    pub fn remove_object(&mut self, cookie: &ObjectCookie) -> Result<(), TracerError> {
+        match self.selected_object.as_ref() {
+            Some(id) if id.id == cookie.id => {
+                self.selected_object = None;
+            }
+            _ => {}
+        }
+
+        if self.objects.get(cookie.id).is_some() {
+            self.objects.remove(cookie.id);
+            self.writer.write(SceneObjectEvent::Remove { id: *cookie })
+        } else {
+            Err(TracerError::NoObjectWithId(cookie.id))
+        }
+    }
+
+    pub fn get_shared_objects(&mut self) -> (Vec<SceneObject>, DataReader<SceneObjectEvent>) {
+        (self.objects.clone(), self.bus.get_reader())
+    }
+
+    pub fn selected_object(&self) -> Option<ObjectCookie> {
+        self.selected_object
+    }
+
+    pub fn select_object(&mut self, screen_x: f64, screen_y: f64) -> Option<ObjectCookie> {
+        let (u, v) = self.image.screen_to_uv(screen_x, screen_y);
+        let ray = Camera::get_ray(self.camera.data(), u, v);
+
+        let t_min = 0.001;
+        let t_max = std::f64::INFINITY;
+        self.selected_object = None;
+        let mut closes_so_far = t_max;
+
+        for (k, obj) in self.objects.iter().enumerate() {
+            if let Some(hit_rec) = obj.hit(&ray, t_min, closes_so_far) {
+                closes_so_far = hit_rec.t;
+                self.selected_object = Some(ObjectCookie { id: k });
+            }
+        }
+        self.selected_object
+    }
+
+    pub fn update(&mut self) -> Result<(), TracerError> {
+        self.bus.update().and_then(|_| self.camera.update())
+    }
+
+    pub fn set_pos(&mut self, cookie: &ObjectCookie, pos: Vec3) -> Result<(), TracerError> {
+        self.objects
+            .get_mut(cookie.id)
+            .ok_or(TracerError::NoObjectWithId(cookie.id))
+            .map(|obj| obj.set_pos(pos))
+            .and_then(|()| {
+                self.writer
+                    .write(SceneObjectEvent::Pos { id: *cookie, pos })
+            })
+    }
+
+    pub fn get_pos(&self, cookie: &ObjectCookie) -> Result<Vec3, TracerError> {
+        self.objects
+            .get(cookie.id)
+            .ok_or(TracerError::NoObjectWithId(cookie.id))
+            .map(|obj| obj.pos())
+    }
 }

--- a/racer-tracer/src/scene/none.rs
+++ b/racer-tracer/src/scene/none.rs
@@ -1,5 +1,7 @@
 use crate::{error::TracerError, scene::SceneLoader};
 
+use super::SceneObject;
+
 pub struct NoneLoader {}
 
 impl NoneLoader {
@@ -9,7 +11,7 @@ impl NoneLoader {
 }
 
 impl SceneLoader for NoneLoader {
-    fn load(&self) -> Result<Vec<Box<dyn crate::geometry::Hittable>>, TracerError> {
+    fn load(&self) -> Result<Vec<SceneObject>, TracerError> {
         Ok(Vec::new())
     }
 }

--- a/racer-tracer/src/scene/random.rs
+++ b/racer-tracer/src/scene/random.rs
@@ -2,12 +2,13 @@ use std::sync::Arc;
 
 use crate::{
     error::TracerError,
-    geometry::{sphere::Sphere, Hittable},
-    material::{dialectric::Dialectric, lambertian::Lambertian, metal::Metal, SharedMaterial},
+    material::{dialectric::Dialectric, lambertian::Lambertian, metal::Metal},
     scene::SceneLoader,
     util::{random_double, random_double_range},
     vec3::{Color, Vec3},
 };
+
+use super::SceneObject;
 
 pub struct Random {}
 
@@ -18,15 +19,14 @@ impl Random {
 }
 
 impl SceneLoader for Random {
-    fn load(&self) -> Result<Vec<Box<dyn crate::geometry::Hittable>>, TracerError> {
-        let mut geometry: Vec<Box<dyn Hittable>> = Vec::new();
-        let ground_material: SharedMaterial =
-            Arc::new(Box::new(Lambertian::new(Color::new(0.5, 0.5, 0.5))));
-        geometry.push(Box::new(Sphere::new(
+    fn load(&self) -> Result<Vec<SceneObject>, TracerError> {
+        let mut geometry: Vec<SceneObject> = Vec::new();
+        let ground_material = Arc::new(Lambertian::new(Color::new(0.5, 0.5, 0.5)));
+        geometry.push(crate::scene::create_sphere(
             Vec3::new(0.0, -1000.0, 0.0),
-            1000.0,
             ground_material,
-        )));
+            1000.0,
+        ));
 
         for a in -11..11 {
             for b in -11..11 {
@@ -41,46 +41,48 @@ impl SceneLoader for Random {
                     if choose_mat < 0.8 {
                         // diffuse
                         let albedo = Color::random() * Color::random();
-                        let mat: SharedMaterial = Arc::new(Box::new(Lambertian::new(albedo)));
-                        geometry.push(Box::new(Sphere::new(center, 0.2, mat)));
+                        let mat = Arc::new(Lambertian::new(albedo));
+                        let center2 = center + Vec3::new(0.0, random_double_range(0.0, 0.5), 0.0);
+
+                        geometry.push(crate::scene::create_movable_sphere(
+                            center, center2, mat, 0.2, 0.0, 1.0,
+                        ));
                     } else if choose_mat > 0.95 {
                         // metal
                         let albedo = Color::random_range(0.5, 1.0);
                         let fuzz = random_double_range(0.0, 0.5);
-                        let mat: SharedMaterial = Arc::new(Box::new(Metal::new(albedo, fuzz)));
-                        geometry.push(Box::new(Sphere::new(center, 0.2, mat)));
+                        let mat = Arc::new(Metal::new(albedo, fuzz));
+                        geometry.push(crate::scene::create_sphere(center, mat, 0.2));
                     } else {
                         // glass
-                        let mat: SharedMaterial = Arc::new(Box::new(Dialectric::new(1.5)));
-                        geometry.push(Box::new(Sphere::new(center, 0.2, mat)));
+                        let mat = Arc::new(Dialectric::new(1.5));
+                        geometry.push(crate::scene::create_sphere(center, mat, 0.2));
                     }
                 }
             }
         }
 
-        let dial_mat: SharedMaterial = Arc::new(Box::new(Dialectric::new(1.5)));
-        geometry.push(Box::new(Sphere::new(
+        let dial_mat = Arc::new(Dialectric::new(1.5));
+        geometry.push(crate::scene::create_sphere(
             Vec3::new(0.0, 1.0, 0.0),
-            1.0,
             dial_mat,
-        )));
+            1.0,
+        ));
 
-        let lamb_mat: SharedMaterial =
-            Arc::new(Box::new(Lambertian::new(Color::new(0.4, 0.2, 0.1))));
-        geometry.push(Box::new(Sphere::new(
+        let lamb_mat = Arc::new(Lambertian::new(Color::new(0.4, 0.2, 0.1)));
+        geometry.push(crate::scene::create_sphere(
             Vec3::new(-4.0, 1.0, 0.0),
-            1.0,
             lamb_mat,
-        )));
-
-        let metal_mat: SharedMaterial =
-            Arc::new(Box::new(Metal::new(Color::new(0.7, 0.6, 0.5), 0.0)));
-
-        geometry.push(Box::new(Sphere::new(
-            Vec3::new(4.0, 1.0, 0.0),
             1.0,
+        ));
+
+        let metal_mat = Arc::new(Metal::new(Color::new(0.7, 0.6, 0.5), 0.0));
+
+        geometry.push(crate::scene::create_sphere(
+            Vec3::new(4.0, 1.0, 0.0),
             metal_mat,
-        )));
+            1.0,
+        ));
 
         Ok(geometry)
     }

--- a/racer-tracer/src/scene_controller.rs
+++ b/racer-tracer/src/scene_controller.rs
@@ -1,39 +1,31 @@
 pub mod interactive;
 
-use slog::Logger;
-
 use crate::{
-    camera::Camera,
-    config::Config,
+    camera::{Camera, SharedCamera},
     error::TracerError,
+    geometry::Hittable,
     image::Image,
-    key_inputs::{KeyCallback, MouseCallback},
+    key_inputs::{KeyEvent, ListenKeyEvents, MousePos},
     scene::Scene,
-    terminal::Terminal,
 };
 
 pub fn create_screen_buffer(image: &Image) -> Vec<u32> {
     vec![0; image.width * image.height]
 }
 
-pub struct SceneData {
-    pub log: Logger,
-    pub term: Terminal,
-    pub config: Config,
-    pub scene: Scene,
-    pub camera: Camera,
-    pub image: Image,
-}
-
 pub trait SceneController: Send + Sync {
-    // Return a vector of key callbacks. The provided closure will be
-    // called when the corresponding key is release/pressed.
-    fn key_inputs(&self) -> Vec<KeyCallback>;
-
-    fn mouse_input(&self) -> Option<MouseCallback>;
+    fn update(
+        &self,
+        dt: f64,
+        keys: Vec<KeyEvent>,
+        mouse_pos: Option<MousePos>,
+        camera: &mut Camera,
+        scene: &mut Scene,
+    ) -> Result<(), TracerError>;
+    fn register_key_inputs(&self) -> Vec<ListenKeyEvents>;
 
     // Render function
-    fn render(&self) -> Result<(), TracerError>;
+    fn render(&self, camera: &SharedCamera, scene: &dyn Hittable) -> Result<(), TracerError>;
 
     // Returns the screen buffer produced by the scene controller.
     // Returns None if no new buffer is available
@@ -42,3 +34,5 @@ pub trait SceneController: Send + Sync {
     // Called when the application wants to exit.
     fn stop(&self);
 }
+
+pub trait SceneRenderer: Send + Sync {}

--- a/racer-tracer/src/scene_controller/interactive.rs
+++ b/racer-tracer/src/scene_controller/interactive.rs
@@ -3,156 +3,206 @@ use std::{
     time::{Duration, Instant},
 };
 
-use minifb::Key;
+use minifb::{Key, MouseButton};
 use slog::Logger;
 use synchronoise::SignalEvent;
 
 use crate::{
-    camera::Camera,
+    camera::{Camera, SharedCamera},
     config::Config,
     error::TracerError,
+    geometry::Hittable,
     image::Image,
     image_action::ImageAction,
-    key_inputs::{KeyCallback, KeyEvent, KeyInputs, MouseCallback},
+    key_inputs::{KeyEvent, ListenKeyEvents, MousePos},
     renderer::{RenderData, Renderer},
     scene::Scene,
     terminal::Terminal,
 };
 
-use super::{create_screen_buffer, SceneController, SceneData};
+use super::{create_screen_buffer, SceneController};
 
 pub struct InteractiveScene<'renderer, 'action> {
     screen_buffer: RwLock<Vec<u32>>,
     preview_buffer: RwLock<Vec<u32>>,
     camera_speed: f64,
-    camera_sensitivity: f32,
-    camera_key_sensitivity: f32,
+    camera_sensitivity: f64,
+    object_move_speed: f64,
     render_image_event: SignalEvent,
     buffer_updated: SignalEvent,
     stop_event: SignalEvent,
-
     log: Logger,
     term: Terminal,
     image_action: &'action dyn ImageAction,
     config: Config,
-    scene: Scene,
-    camera: RwLock<Camera>,
     image: Image,
     renderer: &'renderer dyn Renderer,
     renderer_preview: &'renderer dyn Renderer,
 }
 
 impl<'renderer, 'action> InteractiveScene<'renderer, 'action> {
-    pub fn new(scene_data: SceneData, camera_speed: f64, camera_sensitivity: f32) -> Self {
+    pub fn new(
+        log: Logger,
+        term: Terminal,
+        config: Config,
+        image: Image,
+        camera_speed: f64,
+        camera_sensitivity: f64,
+    ) -> Self {
         Self {
-            screen_buffer: RwLock::new(create_screen_buffer(&scene_data.image)),
-            preview_buffer: RwLock::new(create_screen_buffer(&scene_data.image)),
+            screen_buffer: RwLock::new(create_screen_buffer(&image)),
+            preview_buffer: RwLock::new(create_screen_buffer(&image)),
             camera_speed,
             camera_sensitivity,
-            camera_key_sensitivity: camera_sensitivity * 0.0005, // Just scale it for now.
+            object_move_speed: 0.000001,
             render_image_event: SignalEvent::manual(false),
             buffer_updated: SignalEvent::manual(false),
             stop_event: SignalEvent::manual(false),
-
-            log: scene_data.log,
-            term: scene_data.term,
-            image_action: (&scene_data.config.image_action).into(),
-            scene: scene_data.scene,
-            camera: RwLock::new(scene_data.camera),
-            image: scene_data.image,
-            renderer: (&scene_data.config.renderer).into(),
-            renderer_preview: (&scene_data.config.preview_renderer).into(),
-            config: scene_data.config,
+            log,
+            term,
+            image_action: (&config.image_action).into(),
+            image,
+            renderer: (&config.renderer).into(),
+            renderer_preview: (&config.preview_renderer).into(),
+            config,
         }
     }
 }
 
 impl<'renderer, 'action> SceneController for InteractiveScene<'renderer, 'action> {
-    fn key_inputs(&self) -> Vec<KeyCallback> {
-        vec![
-            KeyInputs::input(KeyEvent::Down, Key::Left, |dt| {
-                self.camera
-                    .write()
-                    .map_err(|e| TracerError::KeyError(e.to_string()))
-                    .map(|mut cam| {
-                        cam.rotate_right(-dt * self.camera_key_sensitivity as f64);
-                    })
-            }),
-            KeyInputs::input(KeyEvent::Down, Key::Right, |dt| {
-                self.camera
-                    .write()
-                    .map_err(|e| TracerError::KeyError(e.to_string()))
-                    .map(|mut cam| {
-                        cam.rotate_right(dt * self.camera_key_sensitivity as f64);
-                    })
-            }),
-            KeyInputs::input(KeyEvent::Down, Key::Up, |dt| {
-                self.camera
-                    .write()
-                    .map_err(|e| TracerError::KeyError(e.to_string()))
-                    .map(|mut cam| {
-                        cam.rotate_up(dt * self.camera_key_sensitivity as f64);
-                    })
-            }),
-            KeyInputs::input(KeyEvent::Down, Key::Down, |dt| {
-                self.camera
-                    .write()
-                    .map_err(|e| TracerError::KeyError(e.to_string()))
-                    .map(|mut cam| {
-                        cam.rotate_up(-dt * self.camera_key_sensitivity as f64);
-                    })
-            }),
-            KeyInputs::input(KeyEvent::Release, Key::R, |_| {
-                self.render_image_event.signal();
-                Ok(())
-            }),
-            KeyInputs::input(KeyEvent::Down, Key::W, |dt| {
-                self.camera
-                    .write()
-                    .map_err(|e| TracerError::KeyError(e.to_string()))
-                    .map(|mut cam| {
-                        cam.go_forward(-dt * self.camera_speed);
-                    })
-            }),
-            KeyInputs::input(KeyEvent::Down, Key::S, |dt| {
-                self.camera
-                    .write()
-                    .map_err(|e| TracerError::KeyError(e.to_string()))
-                    .map(|mut cam| {
-                        cam.go_forward(dt * self.camera_speed);
-                    })
-            }),
-            KeyInputs::input(KeyEvent::Down, Key::A, |dt| {
-                self.camera
-                    .write()
-                    .map_err(|e| TracerError::KeyError(e.to_string()))
-                    .map(|mut cam| {
-                        cam.go_right(-dt * self.camera_speed);
-                    })
-            }),
-            KeyInputs::input(KeyEvent::Down, Key::D, |dt| {
-                self.camera
-                    .write()
-                    .map_err(|e| TracerError::KeyError(e.to_string()))
-                    .map(|mut cam| {
-                        cam.go_right(dt * self.camera_speed);
-                    })
-            }),
-        ]
+    fn update(
+        &self,
+        dt: f64,
+        keys: Vec<KeyEvent>,
+        mouse_pos: Option<MousePos>,
+        camera: &mut Camera,
+        scene: &mut Scene,
+    ) -> Result<(), TracerError> {
+        keys.into_iter().try_for_each(|event| match event {
+            KeyEvent::Released(key) => match key {
+                Key::Q => {
+                    if let Some(mp) = mouse_pos.as_ref() {
+                        scene.select_object(mp.x, mp.y);
+                    }
+                    Ok(())
+                }
+                Key::E => {
+                    if let Some(cookie) = scene.selected_object().as_ref() {
+                        let _ = scene.remove_object(cookie);
+                    }
+                    Ok(())
+                }
+                Key::R => {
+                    self.render_image_event.signal();
+                    Ok(())
+                }
+                Key::NumPadMinus => camera.set_fov(camera.get_vfov() + 1.0),
+                Key::NumPadPlus => camera.set_fov(camera.get_vfov() - 1.0),
+                Key::NumPad8 => camera.set_aperture(camera.get_aperture() + 0.01),
+                Key::NumPad2 => camera.set_aperture(camera.get_aperture() - 0.01),
+                Key::NumPad4 => camera.set_focus_distance(camera.get_focus_distance() + 1.0),
+                Key::NumPad6 => camera.set_focus_distance(camera.get_focus_distance() - 1.0),
+                _ => Ok(()),
+            },
+            KeyEvent::Down(key) => match key {
+                Key::Left => {
+                    if let Some(cookie) = scene.selected_object().as_ref() {
+                        let _ = scene.get_pos(cookie).and_then(|mut pos| {
+                            pos.add(camera.right() * -dt * self.object_move_speed);
+                            scene.set_pos(cookie, pos)
+                        });
+                        Ok(())
+                    } else {
+                        Ok(())
+                    }
+                }
+                Key::Right => {
+                    if let Some(cookie) = scene.selected_object().as_ref() {
+                        let _ = scene.get_pos(cookie).and_then(|mut pos| {
+                            pos.add(camera.right() * dt * self.object_move_speed);
+                            scene.set_pos(cookie, pos)
+                        });
+                        Ok(())
+                    } else {
+                        Ok(())
+                    }
+                }
+                Key::Up => {
+                    if let Some(cookie) = scene.selected_object().as_ref() {
+                        let _ = scene.get_pos(cookie).and_then(|mut pos| {
+                            pos.add(camera.forward() * -dt * self.object_move_speed);
+                            scene.set_pos(cookie, pos)
+                        });
+                        Ok(())
+                    } else {
+                        Ok(())
+                    }
+                }
+                Key::Down => {
+                    if let Some(cookie) = scene.selected_object().as_ref() {
+                        let _ = scene.get_pos(cookie).and_then(|mut pos| {
+                            pos.add(camera.forward() * dt * self.object_move_speed);
+                            scene.set_pos(cookie, pos)
+                        });
+                        Ok(())
+                    } else {
+                        Ok(())
+                    }
+                }
+                Key::W => camera.go_forward(-dt * self.camera_speed),
+                Key::A => camera.go_right(-dt * self.camera_speed),
+                Key::S => camera.go_forward(dt * self.camera_speed),
+                Key::D => camera.go_right(dt * self.camera_speed),
+                _ => Ok(()),
+            },
+            KeyEvent::MouseDelta(key, x, y) => {
+                if key == MouseButton::Left {
+                    camera.rotate(x * self.camera_sensitivity, y * self.camera_sensitivity)
+                } else if key == MouseButton::Right {
+                    if let Some(cookie) = scene.selected_object().as_ref() {
+                        let _ = scene.get_pos(cookie).and_then(|mut pos| {
+                            let move_delta = camera.up() * y * dt * self.object_move_speed
+                                + camera.right() * -x * dt * self.object_move_speed;
+                            pos.add(move_delta);
+                            scene.set_pos(cookie, pos)
+                        });
+                        Ok(())
+                    } else {
+                        Ok(())
+                    }
+                } else {
+                    Ok(())
+                }
+            }
+        })
     }
 
-    fn mouse_input(&self) -> Option<MouseCallback> {
-        Some(Box::new(|x, y| {
-            self.camera
-                .write()
-                .map_err(|e| TracerError::KeyError(e.to_string()))
-                .map(|mut cam| {
-                    cam.rotate(
-                        (x * self.camera_sensitivity) as f64,
-                        (y * self.camera_sensitivity) as f64,
-                    )
-                })
-        }))
+    fn register_key_inputs(&self) -> Vec<ListenKeyEvents> {
+        vec![
+            ListenKeyEvents::Release(vec![
+                Key::Q,
+                Key::R,
+                Key::E,
+                Key::NumPadMinus,
+                Key::NumPadPlus,
+                Key::NumPad8,
+                Key::NumPad2,
+                Key::NumPad4,
+                Key::NumPad6,
+            ]),
+            ListenKeyEvents::Down(vec![
+                Key::Left,
+                Key::Right,
+                Key::Up,
+                Key::Down,
+                Key::W,
+                Key::A,
+                Key::S,
+                Key::D,
+            ]),
+            ListenKeyEvents::MouseMove(MouseButton::Left),
+            ListenKeyEvents::MouseMove(MouseButton::Right),
+        ]
     }
 
     fn get_buffer(&self) -> Result<Option<Vec<u32>>, TracerError> {
@@ -167,7 +217,7 @@ impl<'renderer, 'action> SceneController for InteractiveScene<'renderer, 'action
             })
     }
 
-    fn render(&self) -> Result<(), TracerError> {
+    fn render(&self, camera: &SharedCamera, scene: &dyn Hittable) -> Result<(), TracerError> {
         self.render_image_event
             .wait_timeout(Duration::from_secs(0))
             .then_some(|| ())
@@ -181,9 +231,9 @@ impl<'renderer, 'action> SceneController for InteractiveScene<'renderer, 'action
                     self.renderer_preview
                         .render(RenderData {
                             buffer: &self.preview_buffer,
-                            camera: &self.camera,
+                            camera_data: camera.data(),
                             image: &self.image,
-                            scene: &self.scene,
+                            scene,
                             config: &self.config,
                             cancel_event: None,
                             buffer_updated: None,
@@ -220,9 +270,9 @@ impl<'renderer, 'action> SceneController for InteractiveScene<'renderer, 'action
                     self.renderer
                         .render(RenderData {
                             buffer: &self.screen_buffer,
-                            camera: &self.camera,
+                            camera_data: camera.data(),
                             image: &self.image,
-                            scene: &self.scene,
+                            scene,
                             config: &self.config,
                             cancel_event: Some(&self.render_image_event),
                             buffer_updated: Some(&self.buffer_updated),

--- a/racer-tracer/src/shared_scene.rs
+++ b/racer-tracer/src/shared_scene.rs
@@ -1,0 +1,67 @@
+use crate::{
+    aabb::Aabb,
+    data_bus::DataReader,
+    error::TracerError,
+    geometry::Hittable,
+    scene::{SceneObject, SceneObjectEvent},
+};
+
+pub struct SharedScene {
+    reader: DataReader<SceneObjectEvent>,
+    objects: Vec<SceneObject>,
+    aabb: Aabb,
+}
+
+#[allow(dead_code)]
+impl SharedScene {
+    pub fn new(objects: Vec<SceneObject>, reader: DataReader<SceneObjectEvent>) -> Self {
+        Self {
+            reader,
+            objects,
+            aabb: Aabb::default(),
+        }
+    }
+
+    pub fn update(&mut self) -> Result<(), TracerError> {
+        self.reader.get_messages().and_then(|messages| {
+            messages.into_iter().try_for_each(|action| match action {
+                SceneObjectEvent::Remove { id } => {
+                    self.objects.remove(id.id);
+                    Ok(())
+                }
+                SceneObjectEvent::Pos { id, pos } => {
+                    if let Some(obj) = self.objects.get_mut(id.id) {
+                        obj.set_pos(pos);
+                    }
+                    Ok(())
+                }
+            })
+        })
+    }
+}
+
+impl Hittable for SharedScene {
+    fn hit(
+        &self,
+        ray: &crate::ray::Ray,
+        t_min: f64,
+        t_max: f64,
+    ) -> Option<crate::geometry::HitRecord> {
+        let mut rec = None;
+        let mut closes_so_far = t_max;
+
+        for obj in self.objects.iter() {
+            if let Some(hit_rec) = obj.hit(ray, t_min, closes_so_far) {
+                closes_so_far = hit_rec.t;
+                rec = Some(hit_rec);
+            }
+        }
+
+        rec
+    }
+
+    // TODO: Should revisit trait design as this case fits really unwell.
+    fn bounding_box(&self, _time0: f64, _time1: f64) -> &Aabb {
+        &self.aabb
+    }
+}

--- a/racer-tracer/src/util.rs
+++ b/racer-tracer/src/util.rs
@@ -16,6 +16,12 @@ pub fn random_double_range(min: f64, max: f64) -> f64 {
     rng.gen_range(min..max)
 }
 
+#[allow(dead_code)]
+pub fn random_int_range(min: i32, max: i32) -> i32 {
+    let mut rng = rand::thread_rng();
+    rng.gen_range(min..max)
+}
+
 pub fn random_in_unit_disk() -> Vec3 {
     // TODO: This feels not nice
     loop {

--- a/racer-tracer/src/vec3.rs
+++ b/racer-tracer/src/vec3.rs
@@ -1,9 +1,14 @@
-use std::{fmt, ops};
+use std::{
+    fmt,
+    ops::{self, Index},
+};
 
 use serde::Deserialize;
 
 use crate::util::{random_double, random_double_range};
 
+//https://doc.rust-lang.org/core/arch/x86_64/struct.__m128.html
+//https://doc.rust-lang.org/core/arch/x86_64/fn._mm_mul_ps.html
 #[derive(Default, Clone, Copy, Deserialize)]
 pub struct Vec3 {
     data: [f64; 3],
@@ -146,6 +151,14 @@ impl Vec3 {
         self.data[0] = rpr_neg[1];
         self.data[1] = rpr_neg[2];
         self.data[2] = rpr_neg[3];
+    }
+}
+
+impl Index<usize> for Vec3 {
+    type Output = f64;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.data[index]
     }
 }
 

--- a/resources/scenes/three_balls.yml
+++ b/resources/scenes/three_balls.yml
@@ -48,6 +48,6 @@ geometry:
   - Sphere:
       pos:
         data: [ 1.0, 0.0, -1.0 ]
-      radius: -0.5
+      radius: 0.5
       material: right
 


### PR DESCRIPTION
Had to refactor quite a bit

- Use message passing to update scene between threads.

While implementing the aabb hirearchy I noticed a need to change data that should be reflected between threads.

You could just add a lock but it's pretty annoying using locks everywhere. Added DataBus which implements MPMC. It's a bit overkill since most cases should be covered by SPMC. Just wanted to have something that would work with everything.

This means that the update thread can update whatever implements this pattern and the changes will be reflected in the scene.

There is one caveat and that is that it takes a frame for the changes to be propagated through the bus. It mostly matters for the real time part but that part isn't super important to the resulting product.

A renderer is usually isolated to be able to produce an image. This project is a harness around a part that can produce images.  The harness (real-time part) is just less important. The latecy is not that noteable either.